### PR TITLE
Remove SSH keys from workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,6 @@ jobs:
         with:
           directory: ./
           playbook: ${{ inputs.playbook }}.yml
-          key: ${{ secrets.SSH_KEY }} # assumes that the corresponding pub key was added to the host we are running against
           inventory: |
             [all]
             ${{ inputs.host }}


### PR DESCRIPTION
I have added tailscale ssh to the raspberry pi. SSH keys are no longer needed as tailscale now manages the ssh service with wireguard keys